### PR TITLE
Workflow dirt check Adjustment.

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -224,6 +224,35 @@ export default function App() {
     });
   };
 
+  const deepDiffCheck = (oldData: any, newData: any) => {
+    const oldDataNodes = oldData["nodes"]==null ? [] : oldData["nodes"];
+    const newDataNodes = newData["nodes"]==null ? [] : newData["nodes"];
+    oldData["nodes"] = [];
+    newData["nodes"] = [];
+    let equal = JSON.stringify(oldData) === JSON.stringify(newData);
+    if (equal) {
+      if ( oldDataNodes.length == newDataNodes.length ) {
+        const oldDataNodesMap = oldDataNodes.reduce((map:any, obj:any) => {
+          map.set(obj["id"], JSON.stringify(obj));
+          return map;
+        }, new Map());
+        const newDataNodesMap = newDataNodes.reduce((map:any, obj:any) => {
+          map.set(obj["id"], JSON.stringify(obj));
+          return map;
+        }, new Map());
+        for (let [key, value] of oldDataNodesMap) {
+          if (!newDataNodesMap.has(key) || newDataNodesMap.get(key) !== value) {
+            equal = false;
+            break;
+          }
+        }
+      }
+    }
+    oldData["nodes"]= oldDataNodes;
+    newData["nodes"]= newDataNodes;
+    return equal;
+  }
+
   const checkIsDirty = () => {
     if (curFlowID.current == null) return false;
     const curflow = workflowsTable?.curWorkflow;
@@ -236,7 +265,7 @@ export default function App() {
     } catch (e) {
       console.error("error parsing json", e);
     }
-    const equal = JSON.stringify(graphJson) === JSON.stringify(lastSaved);
+    const equal = deepDiffCheck(graphJson, lastSaved);
     return !equal;
   };
 


### PR DESCRIPTION
## Ignore dirt check inaccuracy after clicking node

Clicking on a node in comfyui adjusts its display order, which changes the sorting in the nodes array, but this does not affect the overall workflow, and it's easy to click on a node after the workflow has been selected, which can lead to incorrect process change judgments. Therefore, this adjustment is made

* After the change, the time consumed increased by 20%.

* I tried to use lodash.isequal for optimization and he only takes 1/10th of the time using JSON.stringify. But the flowchart will use the Float32Array data structure and does not follow the value comparison correctly, so it was not used