### PR TITLE
report error instead of exception dump

### DIFF
--- a/service/scan_my_workflows_folder.py
+++ b/service/scan_my_workflows_folder.py
@@ -53,6 +53,10 @@ def folder_handle(path, recursive, metaInfoOnly, fileList=None):
 def file_handle(name, fileList, file_path, metaInfoOnly):
     with open(file_path, 'r', encoding='utf-8') as f:
         json_data = json.load(f)
+
+    if not isinstance(json_data, (dict,)):
+        logging.error(f"{file_path} not in proper ComfyUI workflow format")
+        return
     
     createTime, updateTime = getFileCreateTime(file_path)
     workspace_info = json_data.get('extra', {}).get('workspace_info', {})   


### PR DESCRIPTION
When the json data is malformed, or someone is storing OTHER data than comfy workflows in the folders, this can cause an exception dump when the manager reads the files.

This simply adds a nicer message around the process.